### PR TITLE
feat: Add MyScratchpad and VSCode Extension link to "Built with Amp" section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ An **unofficial** curated list of resources for Amp, an AI coding agent by Sourc
 
 - [Vibecoding a compiler](https://x.com/GeoffreyHuntley/status/1921336503805886894)
 - [Use Amp & Zapier MCP to turn `*//todo` code comments into Linear issues](https://x.com/jdorfman/status/1926007226969231861)
+- [Building a VSCode Extension with Amp](https://youtu.be/l-VUgg6NmDs?si=5M-D1YOyG4TWk6xS)
 
 ### Amp CLI
 
@@ -92,6 +93,7 @@ npm list --json && echo "identify outdated or vulnerable dependencies" | amp
 
 - [Unofficial Amp CLI Documentation](https://github.com/jdorfman/awesome-amp-code/blob/main/amp_cli_docs.md)
 - [Vibes Catcher](https://www.vibescatcher.com/)  
+- [MyScratchpad](https://github.com/IDAN-DEVS/myscratchpad-vscode-extension)
 
 ### Official Amp Links
 


### PR DESCRIPTION


This commit adds:
- A link to MyScratchpad, a VSCode extension built with Amp.
- A link to a YouTube video showcasing building a VSCode Extension with Amp.