### PR TITLE
fix: correct typos in suggestion issue template

### DIFF
--- a/ci/.github/ISSUE_TEMPLATE/suggestion.yaml
+++ b/ci/.github/ISSUE_TEMPLATE/suggestion.yaml
@@ -16,8 +16,8 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Describe your suggesiton
+      label: Describe your suggestion
       description: How and why is your suggestion useful to this community?
-      placeholder: I wish to see tool <xyz> here becuase it is used for...
+      placeholder: I wish to see tool <xyz> here because it is used for...
     validations:
       required: true


### PR DESCRIPTION
- Fixed the spelling of "suggestion" in the label.
- Corrected the spelling of "because" in the placeholder text.